### PR TITLE
Fix respond_to?/method_missing inconsistency

### DIFF
--- a/lib/dumb_delegator.rb
+++ b/lib/dumb_delegator.rb
@@ -7,21 +7,17 @@ class DumbDelegator < ::BasicObject
   end
 
   kernel = ::Kernel.dup
-  (kernel.instance_methods - [:dup, :clone]).each do |method|
+  (kernel.instance_methods - [:dup, :clone, :respond_to?]).each do |method|
     kernel.__send__ :undef_method, method
   end
   include kernel
-
-  NON_DELEGATED_METHODS = ::Set.new([:equal?, :__id__, :__send__, :dup, :clone, :__getobj__,
-                                     :__setobj__, :marshal_dump, :marshal_load,
-                                     :respond_to?]).freeze
 
   def initialize(target)
     __setobj__(target)
   end
 
   def respond_to?(method)
-    __getobj__.respond_to?(method) || NON_DELEGATED_METHODS.include?(method.to_sym)
+    __getobj__.respond_to?(method) || super
   end
 
   def method_missing(method, *args, &block)

--- a/spec/dumb_delegator_spec.rb
+++ b/spec/dumb_delegator_spec.rb
@@ -118,6 +118,14 @@ describe DumbDelegator do
         subject.respond_to?(method).should be_true
       end
     end
+
+    context "subclasses of DumbDelegator" do
+      subject { Class.new(DumbDelegator) { def foobar; end }.new([]) }
+
+      it "respond to methods defined on the subclass" do
+        subject.respond_to?(:foobar).should be_true
+      end
+    end
   end
 
   describe "#__getobj__" do


### PR DESCRIPTION
Ran into a wierd one today where subclasses of `[DumbDelegator]` would report that they did not respond to methods that were defined directly on the subclass. i.e.

``` ruby
class Foo < DumbDelegator
  def bar; end
end 

Foo.new([]).respond_to?(:bar) #=> false
```

As a result I refactored  `[DumbDelegator#respond_to?]` to be more in line with the way `[DumbDelegator#method_missing]` works.
