### PR TITLE
Fail early with an informative message when the delegatee is set to the ...

### DIFF
--- a/lib/dumb_delegator.rb
+++ b/lib/dumb_delegator.rb
@@ -33,6 +33,7 @@ class DumbDelegator < ::BasicObject
   end
 
   def __setobj__(obj)
+    raise ::ArgumentError,  "Delegation to self is not allowed." if obj.__id__ == __id__
     @__dumb_target__ = obj
   end
 

--- a/spec/dumb_delegator_spec.rb
+++ b/spec/dumb_delegator_spec.rb
@@ -144,5 +144,12 @@ describe DumbDelegator do
       dummy.__setobj__(new_target)
       dummy.foo
     end
+    
+    it "can't delegate to itself" do
+      expect {
+        dummy.__setobj__(dummy)
+        dummy.foo
+      }.to raise_error(ArgumentError, "Delegation to self is not allowed.")
+    end
   end
 end


### PR DESCRIPTION
I just thought it might be helpful to provide a more specific error than SystemStackError for the situation in which an object attempts to delegate to itself.
