### PR TITLE
Delegate constant lookup to Object

### DIFF
--- a/lib/dumb_delegator.rb
+++ b/lib/dumb_delegator.rb
@@ -51,6 +51,10 @@ class DumbDelegator < ::BasicObject
     end
   end
 
+  def self.const_missing(name)
+    ::Object.const_get(name)
+  end
+
   private
 
   def initialize_dup(obj)

--- a/spec/dumb_delegator_spec.rb
+++ b/spec/dumb_delegator_spec.rb
@@ -85,6 +85,12 @@ describe DumbDelegator do
     dummy.instance_exec { true }
   end
 
+  it 'does not interfere with constant lookup' do
+    dummy = Dummy.new(target)
+
+    expect(dummy.foo).to eq('baz')
+  end
+
   describe '#dup' do
     it 'returns a shallow of itself, the delegator (not the underlying object)', :objectspace => true do
       dupped = dummy.dup
@@ -151,5 +157,17 @@ describe DumbDelegator do
         dummy.foo
       }.to raise_error(ArgumentError, 'Delegation to self is not allowed.')
     end
+  end
+end
+
+class DummyForConstLookup
+  def self.foo
+    'baz'
+  end
+end
+
+class Dummy < DumbDelegator
+  def foo
+    DummyForConstLookup.foo
   end
 end


### PR DESCRIPTION
Recently while evaluating this library as a replacement for SimpleDelegator, I ran into problems with constant lookup in the classes where I made the switch. The following script demonstrates the problem:

```
require 'dumb_delegator'
require 'delegate'

class Taco
  def self.sauce
    :hot
  end
end

class Burrito < DumbDelegator
  def sauce
    Taco.sauce
  end
end

class Nachos < SimpleDelegator
  def sauce
    Taco.sauce
  end
end

p taco: Taco.sauce
p burrito: (Burrito.new(Object.new).sauce rescue ':(')
p nachos: Nachos.new(Object.new).sauce
```

`Burrito` and `Nachos` both delegate `#sauce` to `Taco`, which works with `SimpleDelegator` but not `DumbDelegator`. When run, I get this output:

```
pete@balloon:~/projects/test_dumb_delegator$ ruby -v test_dumb_delegator.rb 
ruby 2.1.5p273 (2014-11-13 revision 48405) [x86_64-linux]
{:taco=>:hot}
{:burrito=>":("}
{:nachos=>:hot}
```

This approach is recommended in the [official docs for BasicObject](http://ruby-doc.org//core-2.2.0/BasicObject.html). This could cause problems for users of the library that are decorating objects that inherit from BasicObject themselves.