### PR TITLE
Add optional Module::=== support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Changed
   - Require Ruby >= 2.4. We may still work with older Rubies, but no promises.
 
+### Added
+  - Optional support for using a DumbDelegator instance in a `case` statement. [[12](https://github.com/stevenharman/dumb_delegator/pull/12)]
+
 ## [0.8.1] 2020-01-25
 ### Changed
   - Explicitly Require Ruby >= 1.9.3

--- a/README.md
+++ b/README.md
@@ -79,10 +79,59 @@ class Sugar < DumbDelegator
 end
 
 coffee = Coffee.new
-Sugar.new(Milk.new(coffee)).cost   #=> 2.6
-Sugar.new(Sugar.new(coffee)).cost  #=> 2.4
-Milk.new(coffee).origin            #=> Colombia
-Sugar.new(Milk.new(coffee)).class  #=> Coffee
+Milk.new(coffee).origin           #=> Colombia
+Sugar.new(Sugar.new(coffee)).cost #=> 2.4
+
+cup_o_coffee = Sugar.new(Milk.new(coffee))
+cup_o_coffee.cost                 #=> 2.6
+cup_o_coffee.class                #=> Coffee
+cup_o_coffee.is_a?(Coffee)        #=> true
+cup_o_coffee.is_a?(Milk)          #=> true
+cup_o_coffee.is_a?(Sugar)         #=> true
+```
+
+### Optional `case` statement support
+
+Instances of `DumbDelegator` will delegate `#===` out of the box.
+Meaning an instance can be used in a `case` statement so long as the `when` clauses rely on instance comparison.
+For example, when using a `case` with a regular expression, range, etc...
+
+It's also common to use Class/Module in the `where` clauses.
+In such usage, it's the Class/Module's `::===` method that gets called, rather than the `#===` method on the `DumbDelegator` instance.
+That means we need to override each Class/Module's `::===` method, or even monkey-patch `::Module::===`.
+
+`DumbDelegator` ships with an optional extension to override a Class/Module's `::===` method.
+But you need to extend each Class/Module you use in a `where` clause.
+
+```ruby
+def try_a_case(thing)
+  case thing
+  when MyAwesomeClass
+    "thing is a MyAwesomeClass."
+  when DumbDelegator
+    "thing is a DumbDelegator."
+  else
+    "Bad. This is bad."
+  end
+end
+
+target = MyAwesomeClass.new
+dummy = DumbDelegator.new(target)
+
+try_a_case(dummy) #=> thing is a DumbDelegator.
+
+MyAwesomeClass.extend(DumbDelegator::TripleEqualExt)
+
+try_a_case(dummy) #=> thing is a MyAwesomeClass.
+```
+
+#### Overriding `Module::===`
+If necessary, you could also override the base `Module::===`, though that's pretty invasive.
+
+🐲 _There be dragons!_ 🐉
+
+```ruby
+::Module.extend(DumbDelegator::TripleEqualExt)
 ```
 
 ## Installation

--- a/lib/dumb_delegator.rb
+++ b/lib/dumb_delegator.rb
@@ -1,3 +1,4 @@
+require "dumb_delegator/triple_equal_ext"
 require "dumb_delegator/version"
 
 ##

--- a/lib/dumb_delegator.rb
+++ b/lib/dumb_delegator.rb
@@ -1,5 +1,39 @@
 require "dumb_delegator/version"
 
+##
+# @example
+# class Coffee
+#   def cost
+#     2
+#   end
+#
+#   def origin
+#     "Colombia"
+#   end
+# end
+#
+# class Milk < DumbDelegator
+#   def cost
+#     super + 0.4
+#   end
+# end
+#
+# class Sugar < DumbDelegator
+#   def cost
+#     super + 0.2
+#   end
+# end
+#
+# coffee = Coffee.new
+# Milk.new(coffee).origin           #=> Colombia
+# Sugar.new(Sugar.new(coffee)).cost #=> 2.4
+#
+# cup_o_coffee = Sugar.new(Milk.new(coffee))
+# cup_o_coffee.cost                 #=> 2.6
+# cup_o_coffee.class                #=> Coffee
+# cup_o_coffee.is_a?(Coffee)        #=> true
+# cup_o_coffee.is_a?(Milk)          #=> true
+# cup_o_coffee.is_a?(Sugar)         #=> true
 class DumbDelegator < ::BasicObject
   (::BasicObject.instance_methods - [:equal?, :__id__, :__send__, :method_missing]).each do |method|
     undef_method(method)
@@ -27,10 +61,12 @@ class DumbDelegator < ::BasicObject
     __getobj__.respond_to?(method, include_private) || super
   end
 
+  # @return [Object] The object calls are being delegated to
   def __getobj__
     @__dumb_target__
   end
 
+  # @param obj [Object] Change the object delegate to +obj+.
   def __setobj__(obj)
     raise ::ArgumentError, "Delegation to self is not allowed." if obj.__id__ == __id__
     @__dumb_target__ = obj

--- a/lib/dumb_delegator/triple_equal_ext.rb
+++ b/lib/dumb_delegator/triple_equal_ext.rb
@@ -1,0 +1,29 @@
+class DumbDelegator < ::BasicObject
+  ##
+  # This optional extension enables a Class/Module to support +case+ statements.
+  #
+  # Specifically, it monkey-patches a Class/Module's +:===+ method to check if the +other+ argument is an instance of the extended Class/Module.
+  #
+  # @example Extending a Class/Module to handle class equality for a DumbDelegator instance.
+  #
+  # target = MyAwesomeClass.new
+  # dummy = DumbDelegator.new(target)
+  #
+  # MyAwesomeClass === dummy #=> false
+  # DumbDelegator === dummy  #=> true
+  #
+  # MyAwesomeClass.extend(DumbDelegator::TripleEqualExt)
+  #
+  # MyAwesomeClass === dummy #=> true
+  # DumbDelegator === dummy  #=> true
+  module TripleEqualExt
+    # Case equality for the extended Class/Module and then given +other+.
+    #
+    # @param other [Object] An instance of any Object
+    #
+    # @return [Boolean] If the +other+ is an instance of the Class/Module.
+    def ===(other)
+      super || other.is_a?(self)
+    end
+  end
+end

--- a/spec/dumb_delegator_spec.rb
+++ b/spec/dumb_delegator_spec.rb
@@ -87,6 +87,10 @@ RSpec.describe DumbDelegator do
     end
   end
 
+  it "delegates #===" do
+    expect(dummy === target).to be true
+  end
+
   it "delegates class checks" do
     aggregate_failures do
       expect(dummy.is_a?(Target)).to be(true)
@@ -95,9 +99,26 @@ RSpec.describe DumbDelegator do
     end
   end
 
-  it "delegates ===" do
-    pending("Implement #=== on DumbDelegator")
-    expect(dummy === Target).to be true
+  it "does not delegate ::=== to the target's class" do
+    aggregate_failures do
+      expect(Target === dummy).to be false
+      expect(DumbDelegator === dummy).to be true
+    end
+  end
+
+  context "with a Module/Class's ::=== overridden via extension" do
+    let(:target) { TargetWithTripleEqualExt.new }
+
+    class TargetWithTripleEqualExt
+      extend DumbDelegator::TripleEqualExt
+    end
+
+    it "delegates ::=== to the target's class" do
+      aggregate_failures do
+        expect(TargetWithTripleEqualExt === dummy).to be true
+        expect(DumbDelegator === dummy).to be true
+      end
+    end
   end
 
   it "delegates instance_eval" do


### PR DESCRIPTION
Meaning DumbDelegator instances can work with `case` statements, if the Class/Modules used in the `when` clauses have opted into the TripleEqualExt extension.

Closes #11