### PR TITLE
Basic Introspection Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   - Require Ruby >= 2.4. We may still work with older Rubies, but no promises.
 
 ### Added
+  - Basic introspection support for a DumbDelegator instance: `#inspect`, `#method`, and `#methods`. [[13](https://github.com/stevenharman/dumb_delegator/pull/13)]
   - Optional support for using a DumbDelegator instance in a `case` statement. [[12](https://github.com/stevenharman/dumb_delegator/pull/12)]
 
 ## [0.8.1] 2020-01-25

--- a/lib/dumb_delegator.rb
+++ b/lib/dumb_delegator.rb
@@ -41,13 +41,17 @@ class DumbDelegator < ::BasicObject
   end
 
   kernel = ::Kernel.dup
-  (kernel.instance_methods - [:dup, :clone, :respond_to?, :object_id]).each do |method|
+  (kernel.instance_methods - [:dup, :clone, :method, :methods, :respond_to?, :object_id]).each do |method|
     kernel.__send__(:undef_method, method)
   end
   include kernel
 
   def initialize(target)
     __setobj__(target)
+  end
+
+  def methods(all = true)
+    __getobj__.methods(all) | super
   end
 
   def method_missing(method, *args, &block)

--- a/lib/dumb_delegator.rb
+++ b/lib/dumb_delegator.rb
@@ -50,6 +50,10 @@ class DumbDelegator < ::BasicObject
     __setobj__(target)
   end
 
+  def inspect
+    "#<#{(class << self; self; end).superclass}:#{object_id} obj: #{__getobj__.inspect}>"
+  end
+
   def methods(all = true)
     __getobj__.methods(all) | super
   end

--- a/spec/dumb_delegator_spec.rb
+++ b/spec/dumb_delegator_spec.rb
@@ -199,6 +199,10 @@ RSpec.describe DumbDelegator do
   end
 
   describe "introspection capabilities" do
+    it "provides a human-friendly representation of the delegator and wrapped object" do
+      expect(dummy.inspect).to match(/#<Wrapper:\w+ obj: .+Target.+>/)
+    end
+
     it "reports methods defined on the target" do
       expect(dummy.methods).to include(:target_method, :common_method)
     end

--- a/spec/dumb_delegator_spec.rb
+++ b/spec/dumb_delegator_spec.rb
@@ -197,4 +197,30 @@ RSpec.describe DumbDelegator do
       }.to raise_error(ArgumentError, "Delegation to self is not allowed.")
     end
   end
+
+  describe "introspection capabilities" do
+    it "reports methods defined on the target" do
+      expect(dummy.methods).to include(:target_method, :common_method)
+    end
+
+    it "reports methods defined on the wrapper" do
+      expect(dummy.methods).to include(:wrapper_method, :common_method)
+    end
+
+    it "looks up a named method on the target" do
+      method = dummy.method(:target_method)
+      aggregate_failures do
+        expect(method).not_to be_nil
+        expect(method.receiver).to eq(target)
+      end
+    end
+
+    it "looks up a named method on the wrapper" do
+      method = dummy.method(:wrapper_method)
+      aggregate_failures do
+        expect(method).not_to be_nil
+        expect(method.receiver).to equal(dummy)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Inspired by #6, this adds `#inspect`, `#methods`, and `#method` to a `DumbDelegator` instance. Usage in Pry still isn't great, but this is a start.