### PR TITLE
Refactor DumbDelegator#method_missing to use __getobj__…

### DIFF
--- a/lib/dumb_delegator.rb
+++ b/lib/dumb_delegator.rb
@@ -59,8 +59,8 @@ class DumbDelegator < ::BasicObject
   end
 
   def method_missing(method, *args, &block)
-    if @__dumb_target__.respond_to?(method)
-      @__dumb_target__.__send__(method, *args, &block)
+    if __getobj__.respond_to?(method)
+      __getobj__.__send__(method, *args, &block)
     else
       super
     end

--- a/spec/dumb_delegator_spec.rb
+++ b/spec/dumb_delegator_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe DumbDelegator do
   subject(:dummy) { Wrapper.new(target) }
   let(:target) { Target.new }
+  let(:lazy) { LazyDelegator.new { target } }
 
   class Wrapper < DumbDelegator # rubocop:disable Lint/ConstantDefinitionInBlock
     def wrapper_method
@@ -9,6 +10,16 @@ RSpec.describe DumbDelegator do
 
     def common_method
       ["Method on wrapper.", super].join(" ")
+    end
+  end
+
+  class LazyDelegator < DumbDelegator
+    def initialize(&block)
+      @block = block
+    end
+
+    def __getobj__
+      @__dumb_target__ ||= @block.call
     end
   end
 
@@ -32,6 +43,10 @@ RSpec.describe DumbDelegator do
 
   it "delegates to the target object" do
     expect(dummy.target_method).to eq("Method only on target.")
+  end
+
+  it "delegates to the target object when subclasses override __getobj__" do
+    expect(lazy.target_method).to eq("Method only on target.")
   end
 
   it "delegates to the target object with arguments" do


### PR DESCRIPTION
…instead of @__dumb_target__ directly.

---

From my understanding of the [`Delegator`](https://ruby-doc.org/stdlib-3.0.0/libdoc/delegate/rdoc/Delegator.html#method-i-__raise__) "interface", subclasses (such as [`SimpleDelegator`](https://ruby-doc.org/stdlib-3.0.0/libdoc/delegate/rdoc/SimpleDelegator.html)) are intended to override `__getobj__` and `__setobj__`, and then everything should just work™️.

Recently, I've been implementing a variant of `SimpleDelegator` I've been calling `LazyDelegator`, whose `#initialize` method accepts a block that returns the object to which it should delegate as opposed to accepting the object directly. Then, it also overrides `__getobj__` to lazily assign the result of the block to the relevant instance variable.

When subclassing from `SimpleDelegator`, this works perfectly fine. However, I recently stumbled across this gem (love it, by the way!), but it unfortunately is not a drop-in replacement for `SimpleDelegator` in this case. This is because its `#method_missing` implementation utilizes the `@__dumb_target__` instance variable directly, as opposed to accessing it from `__getobj__`.

I recognize that `DumbDelegator` is not technically a subclass of `Delegator`. But, with this minor change (updating `#method_missing` to use `__getobj__`), it can be a _bit_ more API compatible with `Delegator` / `SimpleDelegator` in my opinion 🙂.

Thanks in advance for your consideration!